### PR TITLE
Update to latest stable 1.2.x release of Kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ version '1.0.1'
 
 buildscript {
     ext.versions = [
-            'kotlin': '1.1.4-3',
+            'kotlin': '1.2.71',
             'okHttp': '3.9.0',
             'rxjava': '2.1.3'
     ]
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${versions.kotlin}"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
     compile "com.squareup.okhttp3:okhttp:${versions.okHttp}"
     compile "io.reactivex.rxjava2:rxjava:${versions.rxjava}"
 }


### PR DESCRIPTION
This also changes the `stdlib` declaration to use `jdk7` instead of `jre7`, resolving issue #1.